### PR TITLE
add spec-only simulcast playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ This repository contains single-page browser tests for simulcast.
 The simulcast stream is split into three different streams using SDP munging in order to expose
 the result both visually as well as to getStats()
 
-* [Chrome](https://fippo.github.io/simulcast-playground/chrome)
+* [Chrome, spec](https://fippo.github.io/simulcast-playground/rid-aѕ-mid)
 * [Firefox](https://fippo.github.io/simulcast-playground/firefox)
+* [Chrome, legacy](https://fippo.github.io/simulcast-playground/chrome)
 
 See the [WebRTCHacks blog post](https://webrtchacks.com/a-playground-for-simulcast-without-an-sfu/) for more information.
 

--- a/rid-as-mid.html
+++ b/rid-as-mid.html
@@ -1,0 +1,241 @@
+<html>
+<head>
+<meta charset="utf-8">
+<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="https://rawgit.com/otalk/sdp/master/sdp.js"></script>
+<script src="https://webrtc.github.io/samples/src/js/third_party/graph.js"></script>
+<style>
+video {
+  width: 320px;
+}
+</style>
+</head>
+<body>
+<div id="local">
+  <h2>Local Video</h2>
+</div>
+<div id="remotes">
+  <h2>Remote Videos</h2>
+</div>
+<script>
+const bitrateSeries = {};
+const bitrateGraphs = {};
+const framerateSeries = {};
+const framerateGraphs = {};
+let lastSendResult;
+let lastRecvResult;
+
+function show(stream, isRemote) {
+    const id = isRemote ? stream.id : 'local';
+
+    const container = document.createElement('div');
+    container.id = id + 'Container';
+    document.getElementById(isRemote ? 'remotes' : 'local').appendChild(container);
+
+    const v = document.createElement('video');
+    v.autoplay = true;
+    v.srcObject = stream;
+    v.onresize = () => v.title = 'video dimensions: ' + v.videoWidth + 'x' + v.videoHeight;
+    container.appendChild(v);
+
+    const bitrateCanvas = document.createElement('canvas');
+    bitrateCanvas.id = id + 'BitrateCanvas';
+    bitrateCanvas.title = 'Bitrate';
+    container.appendChild(bitrateCanvas);
+
+    const bitrateGraph = new TimelineGraphView(id + 'Container', id + 'BitrateCanvas');
+    bitrateGraph.updateEndDate();
+
+    bitrateSeries[id] = new TimelineDataSeries();
+    bitrateGraphs[id] = bitrateGraph;
+
+    const framerateCanvas = document.createElement('canvas');
+    framerateCanvas.id = id + 'FramerateCanvas';
+    framerateCanvas.title = 'Framerate';
+    container.appendChild(framerateCanvas);
+
+    const framerateGraph = new TimelineGraphView(id + 'Container', id + 'FramerateCanvas');
+    framerateGraph.updateEndDate();
+
+    framerateSeries[id] = new TimelineDataSeries();
+    framerateGraphs[id] = framerateGraph;
+}
+
+const pc1 = new RTCPeerConnection({sdpSemantics: 'unified-plan'});
+const pc2 = new RTCPeerConnection({sdpSemantics: 'unified-plan'});
+pc1.onicecandidate = (e) => pc2.addIceCandidate(e.candidate);
+pc2.onicecandidate = (e) => pc1.addIceCandidate(e.candidate);
+pc2.ontrack = (e) => show(e.streams[0], true);
+
+const extensionsToFilter = [
+    'urn:ietf:params:rtp-hdrext:sdes:mid',
+    'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id',
+    'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id',
+];
+const rids = [0, 1, 2];
+navigator.mediaDevices.getUserMedia({video: {width: 1280, height: 720}})
+.then((stream) => {
+    pc1.addTransceiver(stream.getVideoTracks()[0], {
+        streams: [stream],
+        sendEncodings: rids.map(rid => {rid}),
+    });
+    show(stream, false);
+    return pc1.createOffer();
+})
+.then((offer) => {
+    const sections = SDPUtils.splitSections(offer.sdp);
+    const dtls = SDPUtils.getDtlsParameters(sections[1], sections[0]);
+    const ice = SDPUtils.getIceParameters(sections[1], sections[0]);
+    const rtpParameters = SDPUtils.parseRtpParameters(sections[1]);
+
+    // The gist of this hack is that rid and mid have the same wire format.
+    // Kudos to orphis for this clever hack!
+    const rid = rtpParameters.headerExtensions.find(ext => ext.uri === 'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id');
+    rtpParameters.headerExtensions = rtpParameters.headerExtensions.filter(ext => {
+        return !extensionsToFilter.includes(ext.uri);
+    });
+    // This tells the other side that the RID packets are actually mids.
+    rtpParameters.headerExtensions.push({id: rid.id, uri: 'urn:ietf:params:rtp-hdrext:sdes:mid', direction: 'sendrecv'});
+
+    // Filter rtx as we have no wait to reinterpret rrid. Not doing this makes probing use RTX, its not understood
+    // and ramp-up is slower.
+    rtpParameters.codecs = rtpParameters.codecs.filter(c => c.name.toUpperCase() !== 'RTX');
+
+    let sdp = 'v=0\r\n' +
+      'o=mozilla...THIS_IS_SDPARTA-61.0 8324701712193024513 0 IN IP4 0.0.0.0\r\n' +
+      's=-\r\n' +
+      't=0 0\r\n' +
+      'a=fingerprint:sha-256 ' + dtls.fingerprints[0].value + '\r\n' +
+      'a=ice-ufrag:' + ice.usernameFragment + '\r\n' +
+      'a=ice-pwd:' + ice.password + '\r\n' +
+      'a=group:BUNDLE 0 1 2\r\n' +
+      'a=group:BUNDLE 0\r\n' +
+      'a=msid-semantic:WMS *\r\n';
+    const codecs = SDPUtils.writeRtpDescription('video', rtpParameters);
+    sdp += codecs +
+        'a=setup:actpass\r\n' +
+        'a=mid:' + rids[0] + '\r\n' +
+        'a=msid:low low\r\n';
+    sdp += codecs +
+        'a=setup:actpass\r\n' +
+        'a=mid:' + rids[1] + '\r\n' +
+        'a=msid:mid mid\r\n';
+    sdp += codecs +
+        'a=setup:actpass\r\n' +
+        'a=mid:' + rids[2] + '\r\n' +
+        'a=msid:hi hi\r\n';
+
+    return Promise.all([
+        pc1.setLocalDescription(offer),
+        pc2.setRemoteDescription({
+            type: 'offer',
+            sdp,
+        }),
+    ]);
+})
+.then(() => pc2.createAnswer())
+.then(answer => {
+    const sections = SDPUtils.splitSections(answer.sdp);
+    const dtls = SDPUtils.getDtlsParameters(sections[1], sections[0]);
+    const ice = SDPUtils.getIceParameters(sections[1], sections[0]);
+    const rtpParameters = SDPUtils.parseRtpParameters(sections[1]);
+    // Avoid duplicating the mid extension even though Chrome does not care (boo!)
+    rtpParameters.headerExtensions = rtpParameters.headerExtensions.filter(ext => {
+        return !extensionsToFilter.includes(ext.uri);
+    });
+    let sdp = 'v=0\r\n' +
+      'o=mozilla...THIS_IS_SDPARTA-61.0 8324701712193024513 0 IN IP4 0.0.0.0\r\n' +
+      's=-\r\n' +
+      't=0 0\r\n' +
+      'a=fingerprint:' + dtls.fingerprints[0].algorithm + ' ' + dtls.fingerprints[0].value + '\r\n' +
+      'a=ice-ufrag:' + ice.usernameFragment + '\r\n' +
+      'a=ice-pwd:' + ice.password + '\r\n' +
+      'a=group:BUNDLE 0\r\n' +
+      'a=msid-semantic:WMS *\r\n';
+    const codecs = SDPUtils.writeRtpDescription('video', rtpParameters);
+    sdp += codecs;
+    sdp += 'a=setup:active\r\n';
+
+    rids.forEach(rid => {
+        sdp += 'a=rid:' + rid + ' recv\r\n';
+    });
+    sdp += 'a=simulcast:recv ' + rids.join(';') + '\r\n';
+
+    // Re-add headerextensions we filtered.
+    const headerExtensions = SDPUtils.parseRtpParameters(SDPUtils.splitSections(pc1.localDescription.sdp)[1]).headerExtensions;
+    headerExtensions.forEach(ext => {
+        if (extensionsToFilter.includes(ext.uri)) {
+            sdp += 'a=extmap:' + ext.id + ' ' + ext.uri + '\r\n';
+        }
+    });
+    return Promise.all([
+        pc2.setLocalDescription(answer),
+        pc1.setRemoteDescription({
+            type: 'answer',
+            sdp
+        }),
+    ]);
+})
+.then(function() {
+    window.setInterval(() => {
+        pc1.getSenders()[0].getStats().then((res) => {
+            res.forEach((report) => {
+                if (report.type === 'outbound-rtp') {
+                    const now = report.timestamp;
+                    const bytes = report.bytesSent;
+                    const frames = report.framesEncoded;
+                    if (lastSendResult && lastSendResult.get(report.id)) {
+                        const graphName = 'local';
+                        // calculate bitrate
+                        const bitrate = 8000 * (bytes - lastSendResult.get(report.id).bytesSent) /
+                            (now - lastSendResult.get(report.id).timestamp);
+
+                        bitrateSeries[graphName].addPoint(now, bitrate);
+                        bitrateGraphs[graphName].setDataSeries([bitrateSeries[graphName]]);
+                        bitrateGraphs[graphName].updateEndDate();
+
+                        //  calculate framerate.
+                        const framerate = 1000 * (frames - lastSendResult.get(report.id).framesEncoded) /
+                            (now - lastSendResult.get(report.id).timestamp);
+                        framerateSeries[graphName].addPoint(now, framerate);
+                        framerateGraphs[graphName].setDataSeries([framerateSeries[graphName]]);
+                        framerateGraphs[graphName].updateEndDate();
+                    }
+                }
+            });
+            lastSendResult = res;
+        });
+        pc2.getStats().then((res) => {
+            res.forEach((report) => {
+                if (report.type === 'inbound-rtp') {
+                    const now = report.timestamp;
+                    const bytes = report.bytesReceived;
+                    const frames = report.framesDecoded;
+                    if (lastRecvResult && lastRecvResult.get(report.id)) {
+                        const track = res.get(report.trackId).trackIdentifier;
+                        const graphName = track;
+                        // calculate bitrate
+                        const bitrate = 8000 * (bytes - lastRecvResult.get(report.id).bytesReceived) /
+                            (now - lastRecvResult.get(report.id).timestamp);
+
+                        bitrateSeries[graphName].addPoint(now, bitrate);
+                        bitrateGraphs[graphName].setDataSeries([bitrateSeries[graphName]]);
+                        bitrateGraphs[graphName].updateEndDate();
+
+                        //  calculate framerate.
+                        const framerate = 1000 * (frames - lastRecvResult.get(report.id).framesDecoded) /
+                            (now - lastRecvResult.get(report.id).timestamp);
+                        framerateSeries[graphName].addPoint(now, framerate);
+                        framerateGraphs[graphName].setDataSeries([framerateSeries[graphName]]);
+                        framerateGraphs[graphName].updateEndDate();
+                    }
+                }
+            });
+            lastRecvResult = res;
+        });
+    }, 2000);
+})
+.catch(e => console.error(e));
+</script>
+</body>
+</html>


### PR DESCRIPTION
which uses the trick that mid and rid share the same wire format.

@orphis: you're ok with being credited more? The only issue I see with this is that the ramp-up is a bit slow which I think is because rtx is used for probing and I don't see a way to map rrid. Might just filter out rtx as codec