### PR TITLE
Fix generating send encodings

### DIFF
--- a/rid-as-mid.html
+++ b/rid-as-mid.html
@@ -36,7 +36,7 @@ navigator.mediaDevices.getUserMedia({video: {width: 1280, height: 720}})
 .then((stream) => {
     pc1.addTransceiver(stream.getVideoTracks()[0], {
         streams: [stream],
-        sendEncodings: rids.map(rid => {rid}),
+        sendEncodings: rids.map(rid => ({rid})),
     });
     show(stream, false);
     return pc1.createOffer();


### PR DESCRIPTION
Returning an object from an arrow function requires an extra hoop.