### PR TITLE
Fix mid:0 FID group

### DIFF
--- a/chrome.html
+++ b/chrome.html
@@ -133,7 +133,7 @@ navigator.mediaDevices.getUserMedia({video: {width: 1280, height: 720}})
       sdp += codecs +
           'a=mid:0\r\n' +
           'a=msid:low low\r\n' +
-          'a=ssrc:' + videoSSRC1 + ' cname:something\r\n';
+          'a=ssrc:' + videoSSRC1 + ' cname:something\r\n' +
           'a=ssrc:' + rtxSSRC1 + ' cname:something\r\n' +
           'a=ssrc-group:FID ' + videoSSRC1 + ' ' + rtxSSRC1 + '\r\n';
     }


### PR DESCRIPTION
Correct a typo that truncates the FID group of mid:0 while munging the offer.

Before:
a=mid:0
a=msid:low low
a=ssrc:3304166897 cname:something

After:
a=mid:0
a=msid:low low
a=ssrc:3864166950 cname:something
a=ssrc:3094431 cname:something
a=ssrc-group:FID 3864166950 3094431